### PR TITLE
Fixing Veritrans_Snap class not found

### DIFF
--- a/src/PluginForm/MidtransForm.php
+++ b/src/PluginForm/MidtransForm.php
@@ -222,7 +222,7 @@ class MidtransForm extends BasePaymentOffsiteForm {
     else{
       try{
         // Redirect to Midtrans SNAP Redirect page.      
-        $redirect_url = Veritrans_Snap::createTransaction($params)->redirect_url;
+        $redirect_url = \Veritrans_Snap::createTransaction($params)->redirect_url;
         $response = new RedirectResponse($redirect_url);
         $response->send();
       }


### PR DESCRIPTION
Fixing error as per below message

> Error: Class 'Drupal\commerce_midtrans\PluginForm\Veritrans_Snap' not found in Drupal\commerce_midtrans\PluginForm\MidtransForm->buildConfigurationForm() (line 225 of modules/contrib/commerce_midtrans/src/PluginForm/MidtransForm.php)